### PR TITLE
feat: allow psr/container v2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   ],
   "require": {
     "php": "^7.2|^8.0",
-    "psr/container": "^1.0",
+    "psr/container": "^1.0|^2.0",
     "psr/event-dispatcher": "^1.0"
   },
   "provide": {


### PR DESCRIPTION
Hi!

This PR is to allow `psr/container` version `^2.0`. I checked locally and couldn't find an additional needed change.